### PR TITLE
Install-Module The '-AllowPrerelease' parameter must be specified

### DIFF
--- a/powershellgallery/publish.ps1
+++ b/powershellgallery/publish.ps1
@@ -1,4 +1,4 @@
-Install-Module PowerShellGet -RequiredVersion "3.0.11-beta" -Repository PSGallery -Force
+Install-Module PowerShellGet -RequiredVersion "3.0.11-beta" -AllowPrerelease -Repository PSGallery -Force
 Import-Module PowerShellGet -RequiredVersion "3.0.11-beta"
 ls $Env:AZ
 Publish-PSResource  -Path $Env:AZ/Az.Adm -Repository PSGallery -apikey $Env:APIKEY


### PR DESCRIPTION
The '-AllowPrerelease' parameter must be specified when using the Prerelease string in MinimumVersion, MaximumVersion, or RequiredVersion.